### PR TITLE
Add chain reorganization attack

### DIFF
--- a/report_tags.md
+++ b/report_tags.md
@@ -37,6 +37,7 @@
 | CEI | Checks effects interactions patterns is an effective way to prevent reentrancy attacks in a smart contract code. The first step in using this pattern is to perform some checks and verifications in the contract flow. |
 | Chain ID | |
 | Chainlink | |
+| Chain Reorganization Attack | |
 | Change Validation | |
 | CheckPoint | |
 | Check Return Value | |


### PR DESCRIPTION
This PR:
- adds the chain reorganization attack to the tag list

Rationale:
- Chain reorg attack has been accepted as a valid finding on Sherlock a couple of times recently (for ex., [M-02 from Kairos Loan contest on Sherlock](https://solodit.xyz/issues/12279)).